### PR TITLE
add helper names + rm etherpad link + explain slack workspace

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,9 +14,9 @@ humantime: "9:30 am - 4:00 pm ET"    # human-readable times for the workshop e.g
 startdate: 2022-12-01      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
 enddate: 2022-12-02        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
 instructor: ["Abigail Sparling", "Caitlin Bakker", "Jennifer Stubbs"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
-helper: ["TBD"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
+helper: ["Cory Brunson", "Dellena Bloom", "Nancy Ruzycki"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 email: ["amarkee@floridamuseum.ufl.edu"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
-collaborative_notes: https://pad.carpentries.org/2022-12-01-ufl-online  # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document (e.g., https://pad.carpentries.org/2015-01-01-euphoria)
+collaborative_notes: # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document (e.g., https://pad.carpentries.org/2015-01-01-euphoria)
 eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
 ---
 
@@ -304,7 +304,8 @@ available at https://codimd.carpentries.org
 <h2 id="collaborative_notes">Collaborative Notes</h2>
 
 <p>
-We will use this <a href="{{ page.collaborative_notes }}">collaborative document</a> for chatting, taking notes, and sharing URLs and bits of code.
+We will use [Slack](https://slack.com/help/articles/212681477-Sign-in-to-Slack) for chatting, taking notes, and sharing URLs and bits of code.
+Registrants will be invited to the Slack workspace ahead of the workshop.
 </p>
 <hr/>
 {% endif %}


### PR DESCRIPTION
Hi instructors!

No Zoom link yet, but this PR includes some helpers' names and a change from the Etherpad link to Slack instructions. The Slack workspace is not public, so i don't know that the link would make sense, but it's in our Google Doc in case you want to add it.

Cory